### PR TITLE
fix: remove unused useRef to restore build

### DIFF
--- a/src/components/CanvasStage.tsx
+++ b/src/components/CanvasStage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useEffect, forwardRef } from "react";
+import { useMemo, useEffect, forwardRef } from "react";
 import { buildPathFromPoints } from "../lib/path";
 import type { KeyCoord } from "../types";
 


### PR DESCRIPTION
## Summary
- remove unused `useRef` in CanvasStage

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3f46a09e883318ff3715fecbd43f2