### PR TITLE
refactor: modernize UI layout and add clickable keyboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,15 +20,12 @@ function toPoints(text: string, keys: KeyCoord[]) {
 }
 
 export default function App() {
-  // 기본값: 다크 배경에서 잘 보이는 사이언 톤
   const [text, setText] = useState("defqon");
   const [color, setColor] = useState("#ffffff");
   const [width, setWidth] = useState(6);
   const [smooth, setSmooth] = useState(0.4);
   const [showDots, setShowDots] = useState(false);
   const [showKeys, setShowKeys] = useState(true);
-
-  // 옵션 패널은 눌러야 열림
   const [showOptions, setShowOptions] = useState(false);
 
   const svgRef = useRef<SVGSVGElement | null>(null);
@@ -56,9 +53,12 @@ export default function App() {
     setShowKeys(true);
   };
 
+  const handleKeyClick = (label: string) => {
+    setText((t) => t + (label === "Space" ? " " : label));
+  };
+
   return (
-    <div className="min-h-screen bg-[#0a0a0a] text-white selection:bg-cyan-400/20">
-      {/* 헤더 */}
+    <div className="min-h-screen flex flex-col bg-[#0a0a0a] text-white selection:bg-cyan-400/20">
       <header className="sticky top-0 z-20 bg-[#0a0a0a] border-b border-white/20">
         <div className="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3">
@@ -73,23 +73,6 @@ export default function App() {
             </span>
           </div>
           <div className="flex items-center gap-2">
-            <button
-              onClick={() => setShowOptions((v) => !v)}
-              className="px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/15 border border-white/20 text-sm"
-            >
-              Options
-            </button>
-            <label className="hidden sm:inline-flex items-center gap-2 text-sm px-3 py-1.5 rounded-lg border border-white/20 bg-white/10 hover:bg-white/15 cursor-pointer">
-              <input
-                type="checkbox"
-                className="accent-cyan-400"
-                checked={showKeys}
-                onChange={(e) => setShowKeys(e.target.checked)}
-              />
-              Show keys
-            </label>
-
-            {/* Actions (Desktop) */}
             <div className="hidden sm:flex items-center gap-2">
               <button
                 onClick={handleDownloadSVG}
@@ -117,148 +100,14 @@ export default function App() {
         </div>
       </header>
 
-      {/* 메인 */}
-      <main className="mx-auto max-w-5xl px-4 py-5 grid gap-4">
-        {/* 입력 바 (모바일 우선) */}
-        <div className="flex flex-col sm:flex-row gap-3">
-          <div className="flex-1">
-            <label className="block text-xs text-white/60 mb-1">
-              Name / Nickname
-            </label>
-            <input
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              placeholder="이름/닉네임을 입력하세요"
-              className="w-full px-3 sm:px-4 py-2.5 rounded-lg bg-white/5 border border-white/10 outline-none
-                         placeholder:text-white/40 focus:ring-2 focus:ring-cyan-500/60"
-            />
-          </div>
+      <main className="flex-1 w-full mx-auto max-w-5xl px-4 py-5 flex flex-col items-center gap-4">
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="w-full max-w-md px-4 py-2.5 rounded-lg bg-white/5 border border-white/10 outline-none focus:ring-2 focus:ring-cyan-500/60 text-center"
+        />
 
-          {/* 모바일에서 옵션 버튼을 오른쪽에 노출 */}
-          <div className="flex items-end gap-2 sm:hidden">
-            <button
-              onClick={() => setShowOptions((v) => !v)}
-              className="flex-1 px-3 py-2.5 rounded-lg bg-white/10 hover:bg-white/15 border border-white/20 text-sm"
-            >
-              Options
-            </button>
-            <button
-              onClick={() => setShowKeys((v) => !v)}
-              className="px-3 py-2.5 rounded-lg bg-white/10 hover:bg-white/15 border border-white/20 text-sm"
-            >
-              {showKeys ? "Hide keys" : "Show keys"}
-            </button>
-            {/* Actions (Mobile) */}
-            <button
-              onClick={handleDownloadSVG}
-              className="px-3 py-2.5 rounded-lg bg-cyan-500/30 hover:bg-cyan-500/40 border border-cyan-400/40 text-cyan-200 text-sm"
-            >
-              SVG
-            </button>
-            <button
-              onClick={handleDownloadPNG}
-              className="px-3 py-2.5 rounded-lg bg-emerald-500/30 hover:bg-emerald-500/40 border border-emerald-400/40 text-emerald-200 text-sm"
-            >
-              PNG
-            </button>
-            <button
-              onClick={handleReset}
-              className="px-3 py-2.5 rounded-lg bg-white/10 hover:bg-white/15 border border-white/20 text-sm"
-            >
-              Reset
-            </button>
-          </div>
-        </div>
-
-        {/* 옵션 패널 (토글) */}
-        {showOptions && (
-          <section className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 sm:p-5 grid gap-4 sm:grid-cols-2">
-            <div className="grid gap-2">
-              <label className="text-xs text-white/60">Stroke Color</label>
-              <div className="flex items-center gap-3">
-                <input
-                  type="color"
-                  value={color}
-                  onChange={(e) => setColor(e.target.value)}
-                  className="h-10 w-10 cursor-pointer bg-transparent rounded-md overflow-hidden"
-                  title="색상"
-                />
-                <input
-                  value={color}
-                  onChange={(e) => setColor(e.target.value)}
-                  className="flex-1 px-3 py-2 rounded-md bg-black border border-white/10 text-sm
-                             outline-none focus:ring-2 focus:ring-cyan-500/60"
-                />
-              </div>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {[
-                  "#22d3ee",
-                  "#38bdf8",
-                  "#60a5fa",
-                  "#a78bfa",
-                  "#f472b6",
-                  "#34d399",
-                  "#f59e0b",
-                  "#ef4444",
-                ].map((c) => (
-                  <button
-                    key={c}
-                    onClick={() => setColor(c)}
-                    className="h-7 w-7 rounded-md border border-white/10 hover:brightness-110"
-                    style={{ backgroundColor: c }}
-                    aria-label={`pick ${c}`}
-                    title={c}
-                  />
-                ))}
-              </div>
-            </div>
-
-            <div className="grid gap-2">
-              <label className="text-xs text-white/60">
-                Stroke Width: {width}px
-              </label>
-              <input
-                type="range"
-                min={1}
-                max={16}
-                value={width}
-                onChange={(e) => setWidth(+e.target.value)}
-                className="w-full accent-cyan-400"
-              />
-            </div>
-
-            <div className="grid gap-2">
-              <label className="text-xs text-white/60">
-                Smoothing: {smooth}
-              </label>
-              <input
-                type="range"
-                min={0}
-                max={1}
-                step={0.05}
-                value={smooth}
-                onChange={(e) => setSmooth(+e.target.value)}
-                className="w-full accent-cyan-400"
-              />
-            </div>
-
-            <div className="grid gap-2">
-              <label className="text-xs text-white/60">Show Dots</label>
-              <label className="inline-flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  className="accent-cyan-400"
-                  checked={showDots}
-                  onChange={(e) => setShowDots(e.target.checked)}
-                />
-                입력 지점 표시
-              </label>
-            </div>
-          </section>
-        )}
-
-        {/* 캔버스 */}
-        <section>
+        <section className="w-full">
           <CanvasStage
             ref={svgRef}
             points={points}
@@ -268,18 +117,123 @@ export default function App() {
             showDots={showDots}
             showKeys={showKeys}
             keys={qwertyLayout.keys}
+            onKeyClick={handleKeyClick}
           />
           <div className="mt-2 flex items-center justify-between text-xs text-white/40">
             <span>Layout: QWERTY</span>
             <span>{points.length} points</span>
           </div>
         </section>
+
+        <div className="mt-auto w-full">
+          <div className="flex justify-center">
+            <button
+              onClick={() => setShowOptions((v) => !v)}
+              className="px-4 py-2 rounded-lg bg-white/10 hover:bg-white/15 border border-white/20 text-sm"
+            >
+              Options
+            </button>
+          </div>
+          {showOptions && (
+            <section className="mt-4 rounded-2xl border border-white/10 bg-white/[0.04] p-4 grid gap-4 sm:grid-cols-2">
+              <div className="grid gap-2">
+                <label className="text-xs text-white/60">Stroke Color</label>
+                <div className="flex items-center gap-3">
+                  <input
+                    type="color"
+                    value={color}
+                    onChange={(e) => setColor(e.target.value)}
+                    className="h-10 w-10 cursor-pointer bg-transparent rounded-md overflow-hidden"
+                    title="색상"
+                  />
+                  <input
+                    value={color}
+                    onChange={(e) => setColor(e.target.value)}
+                    className="flex-1 px-3 py-2 rounded-md bg-black border border-white/10 text-sm outline-none focus:ring-2 focus:ring-cyan-500/60"
+                  />
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {[
+                    "#22d3ee",
+                    "#38bdf8",
+                    "#60a5fa",
+                    "#a78bfa",
+                    "#f472b6",
+                    "#34d399",
+                    "#f59e0b",
+                    "#ef4444",
+                  ].map((c) => (
+                    <button
+                      key={c}
+                      onClick={() => setColor(c)}
+                      className="h-7 w-7 rounded-md border border-white/10 hover:brightness-110"
+                      style={{ backgroundColor: c }}
+                      aria-label={`pick ${c}`}
+                      title={c}
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid gap-2">
+                <label className="text-xs text-white/60">Stroke Width: {width}px</label>
+                <input
+                  type="range"
+                  min={1}
+                  max={16}
+                  value={width}
+                  onChange={(e) => setWidth(+e.target.value)}
+                  className="w-full accent-cyan-400"
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <label className="text-xs text-white/60">Smoothing: {smooth}</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  value={smooth}
+                  onChange={(e) => setSmooth(+e.target.value)}
+                  className="w-full accent-cyan-400"
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <label className="text-xs text-white/60">Show Dots</label>
+                <label className="inline-flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    className="accent-cyan-400"
+                    checked={showDots}
+                    onChange={(e) => setShowDots(e.target.checked)}
+                  />
+                  입력 지점 표시
+                </label>
+              </div>
+
+              <div className="grid gap-2">
+                <label className="text-xs text-white/60">Show Keys</label>
+                <label className="inline-flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    className="accent-cyan-400"
+                    checked={showKeys}
+                    onChange={(e) => setShowKeys(e.target.checked)}
+                  />
+                  키보드 표시
+                </label>
+              </div>
+            </section>
+          )}
+        </div>
       </main>
 
-      {/* 푸터 */}
       <footer className="mx-auto max-w-5xl px-4 py-6 text-xs text-white/40">
         © {new Date().getFullYear()} KeySignature
       </footer>
     </div>
   );
 }
+

--- a/src/components/CanvasStage.tsx
+++ b/src/components/CanvasStage.tsx
@@ -12,6 +12,7 @@ interface Props {
   showDots?: boolean;
   showKeys?: boolean;
   keys?: KeyCoord[]; // 키보드 오버레이
+  onKeyClick?: (label: string) => void; // 키 클릭 처리
 }
 
 const CanvasStage = forwardRef<SVGSVGElement, Props>(
@@ -24,6 +25,7 @@ const CanvasStage = forwardRef<SVGSVGElement, Props>(
       showDots = false,
       showKeys = true,
       keys = [],
+      onKeyClick,
     },
     ref
   ) => {
@@ -63,7 +65,11 @@ const CanvasStage = forwardRef<SVGSVGElement, Props>(
           keys.map((k) => {
             const rx = 10;
             return (
-              <g key={k.id}>
+              <g
+                key={k.id}
+                onClick={() => k.label && onKeyClick?.(k.label)}
+                className={onKeyClick ? "cursor-pointer" : undefined}
+              >
                 <rect
                   x={k.x + 2}
                   y={k.y + 2}


### PR DESCRIPTION
## Summary
- center input at top and remove placeholder
- move option panel to bottom with toggle button
- allow clicking keys on canvas to input characters

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a407477c508331a56ab480e3e7f594