### PR TITLE
Refine input UI and relocate stats

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,10 +62,10 @@ export default function App() {
       <header className="sticky top-0 z-20 bg-[#0a0a0a] border-b border-white/20">
         <div className="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="h-7 w-7 rounded-md bg-cyan-500/20 ring-1 ring-cyan-400/30 grid place-items-center">
-              <span className="text-cyan-300 text-xs font-bold">KS</span>
+            <div className="h-7 w-7 rounded-md bg-white/10 ring-1 ring-white/30 grid place-items-center">
+              <span className="text-white text-xs font-bold">KS</span>
             </div>
-            <h1 className="text-lg font-semibold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-cyan-300 to-emerald-300">
+            <h1 className="text-lg font-semibold tracking-tight text-white">
               KeySignature
             </h1>
             <span className="ml-2 text-xs text-white/50 hidden sm:inline">
@@ -104,7 +104,7 @@ export default function App() {
         <input
           value={text}
           onChange={(e) => setText(e.target.value)}
-          className="w-full max-w-md px-4 py-2.5 rounded-lg bg-white/5 border border-white/10 outline-none focus:ring-2 focus:ring-cyan-500/60 text-center"
+          className="w-full max-w-md px-4 py-4 rounded-xl bg-white/10 border border-white/20 outline-none focus:ring-2 focus:ring-cyan-500/60 text-center text-lg"
         />
 
         <section className="w-full">
@@ -119,25 +119,20 @@ export default function App() {
             keys={qwertyLayout.keys}
             onKeyClick={handleKeyClick}
           />
-          <div className="mt-2 flex items-center justify-between text-xs text-white/40">
-            <span>Layout: QWERTY</span>
-            <span>{points.length} points</span>
-          </div>
         </section>
 
-        <div className="mt-auto w-full">
-          <div className="flex justify-center">
-            <button
-              onClick={() => setShowOptions((v) => !v)}
-              className="px-4 py-2 rounded-lg bg-white/10 hover:bg-white/15 border border-white/20 text-sm"
-            >
-              Options
-            </button>
-          </div>
-          {showOptions && (
-            <section className="mt-4 rounded-2xl border border-white/10 bg-white/[0.04] p-4 grid gap-4 sm:grid-cols-2">
-              <div className="grid gap-2">
-                <label className="text-xs text-white/60">Stroke Color</label>
+        <div className="w-full flex justify-center">
+          <button
+            onClick={() => setShowOptions((v) => !v)}
+            className="px-5 py-2.5 rounded-full bg-gradient-to-r from-cyan-500 to-emerald-500 text-black font-medium shadow hover:opacity-90"
+          >
+            Options
+          </button>
+        </div>
+        {showOptions && (
+          <section className="w-full mt-4 rounded-2xl border border-white/10 bg-white/[0.04] p-4 grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-2">
+              <label className="text-xs text-white/60">Stroke Color</label>
                 <div className="flex items-center gap-3">
                   <input
                     type="color"
@@ -225,9 +220,13 @@ export default function App() {
                   키보드 표시
                 </label>
               </div>
+
+              <div className="col-span-full mt-4 flex items-center justify-between text-xs text-white/40">
+                <span>Layout: QWERTY</span>
+                <span>{points.length} points</span>
+              </div>
             </section>
-          )}
-        </div>
+        )}
       </main>
 
       <footer className="mx-auto max-w-5xl px-4 py-6 text-xs text-white/40">


### PR DESCRIPTION
## Summary
- restyle header with white logo
- enlarge input and update styling
- move layout/point count into options and modernize options button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a544896df88331b716b5c0ecc21c02